### PR TITLE
Untyped parameters

### DIFF
--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -956,19 +956,23 @@ class TestUtils(unittest.TestCase):
                                 parameters = [["a"], ["b"]])
             tdf.add_parameter("Something", 100, max=100, inclusive_max=True)
             tdf.add_parameter("Another thing", 5, must_be_int=True)
+            tdf.add_parameter("Untyped thing", "whatever", enforce_type_rules=False)
             tdf.add_parameter("Last", 'boo', number_allowed=False, strings_allowed='*')
             return TicDatFactory.create_from_full_schema(tdf.schema(True))
 
         tdf = make_tdf()
         dat = tdf.TicDat(data_table = [[1, 2, 3], [4, 5, 6]],
-                         parameters = [["Something", 100], ["Another thing", 200], ["Last", "goo"]])
+                         parameters = [["Something", 100], ["Another thing", 200], ["Last", "goo"],
+                                       ["Untyped thing", -float("inf")]])
 
         self.assertFalse(tdf.find_data_row_failures(dat))
         dat.parameters["Another thing"] = 200.1
         dat.parameters["Last"] = 100
+        dat.parameters["Bad P"] = dat.parameters.pop("Untyped thing")
         self.assertTrue(set(tdf.find_data_row_failures(dat)) == {("parameters", "Good Name/Value Check")})
-        self.assertTrue(set(next(iter(tdf.find_data_row_failures(dat).values()))) == {"Another thing", "Last"})
+        self.assertTrue(set(next(iter(tdf.find_data_row_failures(dat).values()))) == {"Another thing", "Last", "Bad P"})
 
+        dat.parameters["Untyped thingy"] = dat.parameters.pop("Bad P")
         tdf = make_tdf()
         tdf.add_parameter("Another thing", 5, max=100)
         tdf.add_data_row_predicate("parameters", lambda row: "thing" in row["a"],
@@ -977,12 +981,12 @@ class TestUtils(unittest.TestCase):
         fails = tdf.find_data_row_failures(dat)
         self.assertTrue({k:len(v) for k,v in fails.items()} ==
                         {("parameters", "Good Name/Value Check"): 1,
-                         ("parameters", 'Good Name/Value Check_0'): 2, ('data_table', "boo"): 1})
+                         ("parameters", 'Good Name/Value Check_0'): 3, ('data_table', "boo"): 1})
 
         tdf = make_tdf()
         dat = tdf.TicDat(parameters = [["Something", 90], ["Last", "boo"]])
         self.assertTrue(tdf.create_full_parameters_dict(dat) ==
-                        {"Something": 90, "Another thing": 5, "Last": "boo"})
+                        {"Something": 90, "Another thing": 5, "Last": "boo", "Untyped thing": "whatever"})
 
 
 _scratchDir = TestUtils.__name__ + "_scratch"


### PR DESCRIPTION
Should be possible to specify a parameter without any type rules at all (thus allowing for data passed in as a data structure like a date-time).