### PR TITLE
Max failures

### DIFF
--- a/ticdat/pandatfactory.py
+++ b/ticdat/pandatfactory.py
@@ -1133,13 +1133,13 @@ class PanDatFactory(object):
         assert max_failures > 0, "max_failures should be a positive number"
         verify(verbosity in ["High", "Low"], "verbosity needs to be either 'High' or 'Low'")
         rtn = {}
-        for fk, rows in self._find_foreign_key_failure_rows(pan_dat, max_failures).items():
+        for fk, rows in self._find_foreign_key_failure_rows(pan_dat, max_failures=max_failures).items():
             native, foreign, mappings, card = fk
             rtn[fk] = getattr(pan_dat, native)[rows] if as_table else rows
         if verbosity == "Low":
             rtn = {tuple(k[:2]) + (tuple(k[2]),): v for k,v in rtn.items()}
         return rtn
-    def _find_foreign_key_failure_rows(self, pan_dat, max_failures):
+    def _find_foreign_key_failure_rows(self, pan_dat, max_failures=float("inf")):
         msg  = []
         verify(self.good_pan_dat_object(pan_dat, msg.append),
                "pan_dat not a good object for this factory : %s"%"\n".join(msg))

--- a/ticdat/testing/testpandat_utils.py
+++ b/ticdat/testing/testpandat_utils.py
@@ -691,6 +691,22 @@ class TestUtils(unittest.TestCase):
         pdf.add_foreign_key("pdf_table_two", "pdf_table_three", ["B Field", "C Field"])
         pdf.add_foreign_key("pdf_table_three", "pdf_table_one", ["C Field", "A Field"])
 
+    def test_tdf_max_failures(self):
+        pdf = PanDatFactory(table_one = [["Field"], []], table_two = [[], ["Field"]])
+        for t in ["table_one", "table_two"]:
+            pdf.set_data_type(t, "Field")
+        dat = pdf.PanDat(table_one=DataFrame({"Field": list(range(1,11)) + [-_ for _ in range(1,11)]}),
+                         table_two=DataFrame({"Field": [10.1]*10 + [-2]*10}))
+        errs = pdf.find_data_type_failures(dat)
+        self.assertTrue(len(errs) == 2 and all(len(_) == 10 for _ in errs.values()))
+        errs = pdf.find_data_type_failures(dat, max_failures=11)
+        self.assertTrue(len(errs) == 2)
+        self.assertTrue(any(len(_) == 10 for _ in errs.values()) and any(len(_) == 1 for _ in errs.values()))
+        errs = pdf.find_data_type_failures(dat, max_failures=10)
+        self.assertTrue(len(errs) == 1 and all(len(_) == 10 for _ in errs.values()))
+        errs = pdf.find_data_type_failures(dat, max_failures=9)
+        self.assertTrue(len(errs) == 1 and all(len(_) == 9 for _ in errs.values()))
+
 # Run the tests.
 if __name__ == "__main__":
     if not DataFrame :

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -1499,6 +1499,23 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(small_sch.good_tic_dat_table(by_rows, "foods"))
         self.assertFalse(small_sch.good_tic_dat_table(by_rows, "foods", row_checking="strict"))
 
+    def test_tdf_max_failures(self):
+        tdf = TicDatFactory(table_one = [["Field"], []], table_two = [[], ["Field"]])
+        for t in ["table_one", "table_two"]:
+            tdf.set_data_type(t, "Field")
+        dat = tdf.TicDat(table_one=[[_] for _ in range(1,11)] + [[-_] for _ in range(1,11)],
+                         table_two=[[10.1]]*10 + [[-2]]*10)
+        errs = tdf.find_data_type_failures(dat)
+        self.assertTrue(len(errs) == 2 and all(len(_.pks) == 10 for _ in errs.values()))
+        errs = tdf.find_data_type_failures(dat, 11)
+        self.assertTrue(len(errs) == 2)
+        self.assertTrue(any(len(_.pks) == 10 for _ in errs.values()) and any(len(_.pks) == 1 for _ in errs.values()))
+        errs = tdf.find_data_type_failures(dat, 10)
+        self.assertTrue(len(errs) == 1 and all(len(_.pks) == 10 for _ in errs.values()))
+        errs = tdf.find_data_type_failures(dat, 9)
+        self.assertTrue(len(errs) == 1 and all(len(_.pks) == 9 for _ in errs.values()))
+
+
 _scratchDir = TestUtils.__name__ + "_scratch"
 
 

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -1499,7 +1499,7 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(small_sch.good_tic_dat_table(by_rows, "foods"))
         self.assertFalse(small_sch.good_tic_dat_table(by_rows, "foods", row_checking="strict"))
 
-    def test_tdf_max_failures(self):
+    def test_data_type_max_failures(self):
         tdf = TicDatFactory(table_one = [["Field"], []], table_two = [[], ["Field"]])
         for t in ["table_one", "table_two"]:
             tdf.set_data_type(t, "Field")
@@ -1515,6 +1515,28 @@ class TestUtils(unittest.TestCase):
         errs = tdf.find_data_type_failures(dat, 9)
         self.assertTrue(len(errs) == 1 and all(len(_.pks) == 9 for _ in errs.values()))
 
+    def test_data_row_max_failures(self):
+        tdf = TicDatFactory(table_one = [["Field"], []], table_two = [[], ["Field"]])
+        for t in ["table_one", "table_two"]:
+            tdf.set_data_type(t, "Field")
+        for table, dts in tdf.data_types.items():
+            for field, dt in dts.items():
+                if table == "table_one":
+                    tdf.add_data_row_predicate(t, lambda row: dt.valid_data(row["Field"]))
+                else:
+                    tdf.add_data_row_predicate(t, lambda row: True if not dt.valid_data(row["Field"]) else "Oops",
+                                               predicate_failure_response="Error Message")
+        dat = tdf.TicDat(table_one=[[_] for _ in range(1,11)] + [[-_] for _ in range(1,11)],
+                         table_two=[[10.1]]*10 + [[-2]]*10)
+        errs = tdf.find_data_row_failures(dat)
+        self.assertTrue(len(errs) == 2 and all(len(_) == 10 for _ in errs.values()))
+        errs = tdf.find_data_row_failures(dat, max_failures=11)
+        self.assertTrue(len(errs) == 2)
+        self.assertTrue(any(len(_) == 10 for _ in errs.values()) and any(len(_) == 1 for _ in errs.values()))
+        errs = tdf.find_data_row_failures(dat, max_failures=10)
+        self.assertTrue(len(errs) == 1 and all(len(_) == 10 for _ in errs.values()))
+        errs = tdf.find_data_row_failures(dat, max_failures=9)
+        self.assertTrue(len(errs) == 1 and all(len(_) == 9 for _ in errs.values()))
 
 _scratchDir = TestUtils.__name__ + "_scratch"
 


### PR DESCRIPTION
`max_failures` argument to limit the number of failures enumerated for data type failures, foreign key failures, and data row failures.

Row duplicate failures are far less likely to blow up to huge numbers, so those will be addressed as requested.