### PR TITLE
0.2.19.6

### DIFF
--- a/examples/expert_section/cplex/diet.py
+++ b/examples/expert_section/cplex/diet.py
@@ -11,7 +11,8 @@
 # to solution_data.xlsx.
 
 from ticdat import TicDatFactory, standard_main
-from docplex.mp.model import Model
+import docplex
+__version__ =  docplex.__version__ # not needed, helps deploy on Enframe
 
 # ------------------------ define the input schema --------------------------------
 # There are three input tables, with 4 primary key fields and 4 data fields.
@@ -66,7 +67,7 @@ def solve(dat):
     assert not input_schema.find_data_type_failures(dat)
     assert not input_schema.find_data_row_failures(dat)
 
-    mdl = Model('diet')
+    mdl = docplex.mp.model.Model('diet')
 
     nutrition = {c:mdl.continuous_var(lb=n["Min Nutrition"], ub=n["Max Nutrition"], name=c)
                 for c,n in dat.categories.items()}

--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -14,7 +14,7 @@ from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
 from ticdat.opl import opl_run, create_opl_mod_text, create_opl_mod_output_text
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
-__version__ = '0.2.19.5'
+__version__ = '0.2.19.6'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "opl_run", "create_opl_mod_text", "create_opl_mod_output_text", "ampl_format",
            "gurobi_env", "verify", "dat_restricted", "sln_restricted"]

--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -14,7 +14,7 @@ from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
 from ticdat.opl import opl_run, create_opl_mod_text, create_opl_mod_output_text
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
-__version__ = '0.2.19.4'
+__version__ = '0.2.19.5'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "opl_run", "create_opl_mod_text", "create_opl_mod_output_text", "ampl_format",
            "gurobi_env", "verify", "dat_restricted", "sln_restricted"]

--- a/ticdat/jsontd.py
+++ b/ticdat/jsontd.py
@@ -89,8 +89,8 @@ class JsonTicFactory(freezable_factory(object, "_isFrozen")) :
         tic_dat_dict = self._create_tic_dat_dict(jdict)
         missing_tables = set(self.tic_dat_factory.all_tables).difference(tic_dat_dict)
         if missing_tables:
-            print ("The following table names could not be found in the %s file.\n%s\n"%
-                   (json_file_path,"\n".join(missing_tables)))
+            print ("The following table names could not be found in the json file/string\n%s\n"%
+                   "\n".join(missing_tables))
         rtn = self.tic_dat_factory.TicDat(**tic_dat_dict)
         rtn = self.tic_dat_factory._parameter_table_post_read_adjustment(rtn)
         if freeze_it:

--- a/ticdat/pandatfactory.py
+++ b/ticdat/pandatfactory.py
@@ -643,6 +643,9 @@ class PanDatFactory(object):
                    "%s does not refer to one of %s 's fields"%(k, native_table))
             verify(v in self._all_fields(foreign_table),
                    "%s does not refer to one of %s 's fields"%(v, foreign_table))
+        if utils.does_new_fk_complete_circle(native_table, foreign_table, self):
+            print(f"*** A circular foreign key relationship will be creating by adding the {native_table} to " +
+                  f"{foreign_table} connection")
         self._foreign_keys[native_table, foreign_table].add(tuple(_mappings.items()))
     def _trigger_has_been_used(self):
         self._has_been_used = True

--- a/ticdat/pandatfactory.py
+++ b/ticdat/pandatfactory.py
@@ -207,17 +207,22 @@ class PanDatFactory(object):
         verify(value == "N/A" or (utils.numericish(value) and (0 < value < float("inf"))) or (value is None),
            "infinity_io_flag needs to be 'N/A' (to indicate it isn't being used), or None, or a positive finite number")
         self._infinity_io_flag[0] = value
+        self._none_as_infinity_bias_cache.clear()
     def _none_as_infinity_bias(self, t, f):
         if self.infinity_io_flag is not None:
             return None
         assert t in self.all_tables
-        fld_type = self.data_types.get(t, {}).get(f)
-        if fld_type and fld_type.number_allowed and not fld_type.valid_data(None):
-            verify(not (fld_type.valid_data(float("inf")) and fld_type.valid_data(-float("inf"))),
-                   f"None cannot be used as an infinity IO flag ")
-            for rtn in [1, -1]:
-                if fld_type.valid_data(rtn * float("inf")):
-                    return rtn
+        if (t,f) not in self._none_as_infinity_bias_cache:
+            def _f():
+                fld_type = self.data_types.get(t, {}).get(f)
+                if fld_type and fld_type.number_allowed and not fld_type.valid_data(None):
+                    verify(not (fld_type.valid_data(float("inf")) and fld_type.valid_data(-float("inf"))),
+                           f"None cannot be used as an infinity IO flag for {t}.{f}")
+                    for rtn in [1, -1]:
+                        if fld_type.valid_data(rtn * float("inf")):
+                            return rtn
+            self._none_as_infinity_bias_cache[t, f] = _f()
+        return self._none_as_infinity_bias_cache[t, f]
     def _dtypes_for_pandas_read(self, table):
         '''
         we expect other routines inside ticdat to access this routine, even though it starts with _
@@ -381,6 +386,7 @@ class PanDatFactory(object):
 
         self._data_types[table][field] = TypeDictionary.safe_creator(number_allowed, inclusive_min, inclusive_max,
                                             min, max, must_be_int, strings_allowed, nullable, datetime)
+        self._none_as_infinity_bias_cache.clear()
 
     def clear_data_type(self, table, field):
         """
@@ -399,6 +405,7 @@ class PanDatFactory(object):
         verify(not self._has_been_used,
                "The data types can't be changed after a PanDatFactory has been used.")
         del(self._data_types[table][field])
+        self._none_as_infinity_bias_cache.clear()
 
     def add_data_row_predicate(self, table, predicate, predicate_name=None,
                                predicate_kwargs_maker=None,
@@ -704,6 +711,8 @@ class PanDatFactory(object):
         self._foreign_keys = clt.defaultdict(set)
         self._parameters = {}
         self._infinity_io_flag = ["N/A"]
+        self._none_as_infinity_bias_cache = {}
+
 
         self.all_tables = frozenset(init_fields)
         superself = self

--- a/ticdat/pandatfactory.py
+++ b/ticdat/pandatfactory.py
@@ -1014,7 +1014,9 @@ class PanDatFactory(object):
                         predicate_kwargs_maker_results[rpi.predicate_kwargs_maker] = _predicate_kwargs
                     predicate_kwargs = predicate_kwargs_maker_results[rpi.predicate_kwargs_maker]
                 if not isinstance(predicate_kwargs, dict):
-                    rtn[TPN(tbl, pn)] = PKEM('*', str(predicate_kwargs))
+                    rtn[TPN(tbl, pn)] = PKEM('*', predicate_kwargs
+                                        if (isinstance(predicate_kwargs, str) and "Exception<" in predicate_kwargs)
+                                        else f"predicate_kwargs_maker failed to return a dict")
                 else:
                     if rpi.predicate_failure_response == "Boolean":
                         def _p(row):

--- a/ticdat/pandatfactory.py
+++ b/ticdat/pandatfactory.py
@@ -10,8 +10,9 @@ import ticdat.pandatio as pandatio
 from itertools import count
 try:
     from pandas import isnull
+    import numpy
 except:
-    isnull = None
+    isnull = numpy = None
 import collections as clt
 from ticdat.pgtd import PostgresPanFactory
 try:
@@ -28,7 +29,8 @@ def _faster_df_apply(df, func):
         row_dict = {f:v for f,v in zip(cols, row[1:])}
         data.append(func(row_dict))
         index.append(row[0])
-    return pd.Series(data, index=index)
+    # will default to float for empty Series, like original pandas
+    return pd.Series(data, index=index, **({"dtype": numpy.float64} if not data else {}))
 
 class PanDatFactory(object):
     """

--- a/ticdat/pandatio.py
+++ b/ticdat/pandatio.py
@@ -119,7 +119,7 @@ class JsonPanFactory(freezable_factory(object, "_isFrozen")):
                "The following (table, field) pairs are missing fields.\n%s" % [(t, f) for t,f in missing_fields])
         missing_tables = sorted(set(self.pan_dat_factory.all_tables).difference(rtn))
         if missing_tables:
-            print("The following table names could not be found in the SQLite database.\n%s\n" %
+            print("The following table names could not be found in the json file/string.\n%s\n" %
                   "\n".join(missing_tables))
         return _clean_pandat_creator(self.pan_dat_factory, rtn, json_read=True)
 

--- a/ticdat/pgtd.py
+++ b/ticdat/pgtd.py
@@ -104,13 +104,10 @@ class _PostgresFactory(freezable_factory(object, "_isFrozen"),):
         rtn = []
         fks = self._fks()
         def process_table(t, already_seen=None):
-            already_seen = already_seen or []
-            if t in already_seen:
-                return # emergency fail for circular reference to avoid endless recursion
-            already_seen.append(t)
-            if t not in rtn:
+            already_seen = already_seen or [] # emergency fail for circular reference to avoid endless recursion
+            if t not in rtn + already_seen:
                 for fk in fks.get(t, ()):
-                    process_table(fk.foreign_table, already_seen)
+                    process_table(fk.foreign_table, already_seen+[t])
                 rtn.append(t)
 
         list(map(process_table, self.tdf.all_tables))

--- a/ticdat/pgtd.py
+++ b/ticdat/pgtd.py
@@ -196,7 +196,7 @@ class _PostgresFactory(freezable_factory(object, "_isFrozen"),):
         all_fields = lambda t: self.tdf.primary_key_fields.get(t, ()) + self.tdf.data_fields.get(t, ())
         good_forced_field_type_entry = lambda k, v: isinstance(k, tuple) and len(k) == 2 \
                         and k[1] in all_fields(k[0]) and v in \
-                        ["text", "integer", "float", "bool", "boolean", "timestamp"]
+                        ["text", "integer", "float", "bool", "boolean", "timestamp", "date"]
         verify(dictish(forced_field_types) and
                all(good_forced_field_type_entry(k, v) for k,v in forced_field_types.items()),
                "bad forced_field_types argument")

--- a/ticdat/testing/test_pgtd.py
+++ b/ticdat/testing/test_pgtd.py
@@ -812,6 +812,36 @@ class TestPostres(unittest.TestCase):
         self.assertTrue(pdf._same_data(pan_dat, pan_dat_2, epsilon=1e-4))
         self.assertTrue(set(pan_dat.foo.columns).difference(pan_dat_2.foo.columns) == {'c'})
 
+    def testDateTimeTwo(self):
+        schema = test_schema + "_date_two"
+        tdf = TicDatFactory(table_with_stuffs = [["field one"], ["field two"]],
+                            parameters = [["a"],["b"]])
+        tdf.add_parameter("p1", "Dec 15 1970", datetime=True)
+        tdf.add_parameter("p2", None, datetime=True, nullable=True)
+        tdf.set_data_type("table_with_stuffs", "field one", datetime=True)
+        tdf.set_data_type("table_with_stuffs", "field two", datetime=True, nullable=True)
+
+        n = str(datetime.datetime.now())
+        dat = tdf.TicDat(table_with_stuffs = [[dateutil.parser.parse("July 11 1972"), None],
+                                              [dateutil.parser.parse(n[0:n.find(" ")]),
+                                               dateutil.parser.parse("Sept 11 2011")]],
+                         parameters = [["p1", "7/11/1911"], ["p2", None]])
+        self.assertFalse(tdf.find_data_type_failures(dat) or tdf.find_data_row_failures(dat))
+
+        tdf.pgsql.write_schema(self.engine, schema,
+                               forced_field_types={("table_with_stuffs", "field one"): "date",
+                                                   ("table_with_stuffs", "field two"): "date"})
+        tdf.pgsql.write_data(dat, self.engine, schema)
+
+        dat_2 = tdf.pgsql.create_tic_dat(self.engine, schema)
+        self.assertFalse(tdf._same_data(dat, dat_2, nans_are_same_for_data_rows=True))
+        dat.parameters['p1']['b'] = dateutil.parser.parse(dat.parameters['p1']['b'])
+        self.assertTrue(tdf._same_data(dat, dat_2, nans_are_same_for_data_rows=True))
+
+        pdf = PanDatFactory.create_from_full_schema(tdf.schema(include_ancillary_info=True))
+        pan_dat = pdf.pgsql.create_pan_dat(self.engine, schema)
+        dat_3 = pdf.copy_to_tic_dat(pan_dat)
+        self.assertTrue(tdf._same_data(dat, dat_3, nans_are_same_for_data_rows=True))
 
 test_schema = 'test'
 

--- a/ticdat/testing/test_pgtd.py
+++ b/ticdat/testing/test_pgtd.py
@@ -785,6 +785,17 @@ class TestPostres(unittest.TestCase):
         tdf = TicDatFactory(boger=[["A Fields"], ["556f"]])
         tdf.pgsql.write_schema(self.engine, schema)
 
+    def testCircularFks(self):
+        schema = test_schema + "circular_fks"
+        tdf = TicDatFactory(table_one=[["A Field"], []], table_two=[["B Field"],[]], table_three=[["C Field"], []])
+        tdf.add_foreign_key("table_one", "table_two", ["A Field", "B Field"])
+        tdf.add_foreign_key("table_two", "table_three", ["B Field", "C Field"])
+        tdf.add_foreign_key("table_three", "table_one", ["C Field", "A Field"])
+        tdf.pgsql.write_schema(self.engine, schema, include_ancillary_info=False)
+        t_ = [["a"], ["b"], ["c"]]
+        dat = tdf.TicDat(table_one=t_, table_two=t_, table_three=t_)
+        tdf.pgsql.write_data(dat, self.engine, schema)
+
 
 test_schema = 'test'
 

--- a/ticdat/testing/test_slow_bernardo.py
+++ b/ticdat/testing/test_slow_bernardo.py
@@ -1,0 +1,103 @@
+# This test needs a few things not in ticdat source to run - the kehaar package and the bernardo_slowby directory
+# Pete knows how to track down both of these (bernardo_slowby.zip for the latter)
+# This test is just for performance tracking.
+try:
+    import sqlalchemy as sa
+except:
+    sa = None
+try:
+    import testing.postgresql as testing_postgresql
+except:
+    testing_postgresql = None
+try:
+    import kehaar
+except:
+    kehaar = None
+from ticdat.testing.ticdattestutils import flagged_as_run_alone, fail_to_debugger
+import ticdat.utils as utils
+import unittest
+import os
+import inspect
+from functools import wraps
+import time
+from ticdat import PanDatFactory
+
+def _codeFile() :
+    return  os.path.realpath(os.path.abspath(inspect.getsourcefile(_codeFile)))
+__codeFile = _codeFile()
+def _codeDir():
+    return os.path.dirname(__codeFile)
+
+def _timeit(func, expected_time):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.time()
+        result = func(*args, **kwargs)
+        end = time.time()
+        exe_time = end - start
+        print(f"**** {func.__name__} executed in {exe_time} expected time of {expected_time}")
+        return result
+    return wrapper
+
+def _forced_field_types():
+    rtn = {('products', 'Freight Class'): 'text', ('demand', 'Max Demand'): 'text'}
+    for t, dvs in kehaar.input_schema.default_values.items():
+        for f, dv in dvs.items():
+            if isinstance(dv, str) and not kehaar.input_schema.data_types.get(t, {}).get(f, None):
+                rtn[t, f] = "text"
+    return rtn
+
+#@fail_to_debugger
+class TestSlowBernardo(unittest.TestCase):
+    def setUp(self):
+        try:
+            self.postgresql = testing_postgresql.Postgresql()
+            self.engine = sa.create_engine(self.postgresql.url())
+            self.engine_fail = None
+        except Exception as e:
+            self.postgresql = self.engine = None
+            self.engine_fail = e
+        if self.engine_fail:
+            print(f"!!!!Engine failed to load due to {self.engine_fail}")
+        if self.engine:
+            for test_schema in test_schemas:
+                if utils.safe_apply(lambda: test_schema in sa.inspect(self.engine).get_schema_names())():
+                    self.engine.execute(sa.schema.DropSchema(test_schema, cascade=True))
+
+    def tearDown(self):
+        if self.postgresql:
+            self.engine.dispose()
+            self.postgresql.stop()
+
+    def test_tdf(self):
+        tdf = kehaar.input_schema
+        dat = _timeit(tdf.csv.create_tic_dat, 90)(os.path.join(_codeDir(), "bernardo_slowby"))
+        tdf.pgsql.write_schema(self.engine, test_schemas[0], include_ancillary_info=False,
+                               forced_field_types=_forced_field_types())
+        _timeit(tdf.pgsql.write_data, 90)(dat, self.engine, test_schemas[0], dsn=self.postgresql.dsn())
+        _timeit(tdf.pgsql.create_tic_dat, 50)(self.engine, test_schemas[0])
+
+    def test_pdf(self):
+        pdf = PanDatFactory.create_from_full_schema(kehaar.input_schema.schema(include_ancillary_info=True))
+        dat = _timeit(pdf.csv.create_pan_dat, 90)(os.path.join(_codeDir(), "bernardo_slowby"))
+        pdf.pgsql.write_schema(self.engine, test_schemas[1], include_ancillary_info=False,
+                               forced_field_types=_forced_field_types())
+        # it takes a bit longer because thare might be infinities to manage into PG
+        _timeit(pdf.pgsql.write_data, 180)(dat, self.engine, test_schemas[1])
+        _timeit(pdf.pgsql.create_pan_dat, 50)(self.engine, test_schemas[1])
+
+
+    def test_pdf_2(self):
+        pdf = PanDatFactory.create_from_full_schema(kehaar.input_schema.schema(include_ancillary_info=True))
+        pdf.set_infinity_io_flag("N/A") # this speeds thing up, since less munging
+        dat = _timeit(pdf.csv.create_pan_dat, 5)(os.path.join(_codeDir(), "bernardo_slowby"))
+        pdf.pgsql.write_schema(self.engine, test_schemas[2], include_ancillary_info=False,
+                               forced_field_types=_forced_field_types())
+        _timeit(pdf.pgsql.write_data, 90)(dat, self.engine, test_schemas[2])
+        _timeit(pdf.pgsql.create_pan_dat, 5)(self.engine, test_schemas[2])
+
+test_schemas = [f"test_schema_{_}" for _ in range(5)]
+
+# Run the tests.
+if __name__ == "__main__":
+    unittest.main()

--- a/ticdat/testing/testpandat_io.py
+++ b/ticdat/testing/testpandat_io.py
@@ -706,7 +706,8 @@ class TestIO(unittest.TestCase):
         for attr, path in [["csv", core_path+"_csv"], ["xls", core_path+".xlsx"], ["sql", core_path+".db"],
                            ["json", core_path+".json"]]:
             f_or_d = "directory" if attr == "csv" else "file"
-            write_func, write_kwargs = utils._get_write_function_and_kwargs(pdf, path, f_or_d)
+            write_func, write_kwargs = utils._get_write_function_and_kwargs(pdf, path, f_or_d,
+                                                                            case_space_table_names=False)
             write_func(dat, path, **write_kwargs)
             dat_1 = utils._get_dat_object(pdf, "create_pan_dat", path, f_or_d, False)
             self.assertTrue(pdf._same_data(dat, dat_1, nans_are_same_for_data_rows=True))

--- a/ticdat/testing/testpandat_utils.py
+++ b/ticdat/testing/testpandat_utils.py
@@ -685,6 +685,11 @@ class TestUtils(unittest.TestCase):
         pdf.add_data_row_predicate("arcs", None, 0)
         pdf = pdf.clone()
         self.assertTrue(set(pdf._data_row_predicates["arcs"]) == {"dummy"})
+        pdf = PanDatFactory(pdf_table_one=[["A Field"], []], pdf_table_two=[["B Field"],[]],
+                            pdf_table_three=[["C Field"], []])
+        pdf.add_foreign_key("pdf_table_one", "pdf_table_two", ["A Field", "B Field"])
+        pdf.add_foreign_key("pdf_table_two", "pdf_table_three", ["B Field", "C Field"])
+        pdf.add_foreign_key("pdf_table_three", "pdf_table_one", ["C Field", "A Field"])
 
 # Run the tests.
 if __name__ == "__main__":

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -1369,6 +1369,7 @@ class TestUtils(unittest.TestCase):
         sln = read_sln()
         self.assertTrue({t:len(getattr(sln, t)) for t in funky_diet.solution_schema.all_tables} ==
                         {"buy_food": 3, "consume_nutrition": 4, "weird_table": 0, "parameters": 1})
+
         dat.nutrition_quantities["pizza", "junk"] = {}
         dat.categories["weirdness"] = dat.categories["wokeness"] = [100, 20]
         funky_diet.input_schema.json.write_file(dat, os.path.join(data_path, "input.json"), allow_overwrite=True)
@@ -1392,6 +1393,16 @@ class TestUtils(unittest.TestCase):
         with patch.object(sys, 'argv', [module_path, "-i", "junk", "-o", os.path.join(data_path, "output.json"),
                                         "-a", "checks_the_unit_test_result"]):
             utils.standard_main(funky_diet.input_schema, funky_diet.solution_schema, funky_diet.solve)
+
+        with patch.object(sys, 'argv', [module_path, "-i", os.path.join(data_path, "input.json"),
+                                        "-o", os.path.join(data_path, "output_csvs")]):
+            utils.standard_main(funky_diet.input_schema, funky_diet.solution_schema, funky_diet.solve)
+        self.assertTrue(os.path.exists(os.path.join(data_path, "output_csvs", "consume_nutrition.csv")))
+        with patch.object(sys, 'argv', [module_path, "-i", os.path.join(data_path, "input.json"),
+                                        "-o", os.path.join(data_path, "output_csvs_2")]):
+            utils.standard_main(funky_diet.input_schema, funky_diet.solution_schema, funky_diet.solve,
+                                case_space_table_names=True)
+        self.assertTrue(os.path.exists(os.path.join(data_path, "output_csvs_2", "Consume Nutrition.csv")))
         sys.modules.pop(funky_diet.solve.__module__)
 
     def testThirty(self):

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -1210,7 +1210,8 @@ class TestUtils(unittest.TestCase):
         for attr, path in [["csv", core_path+"_csv"], ["xls", core_path+".xlsx"], ["sql", core_path+".sql"],
                            ["json", core_path+".json"]]:
             f_or_d = "directory" if attr == "csv" else "file"
-            write_func, write_kwargs = utils._get_write_function_and_kwargs(tdf, path, f_or_d)
+            write_func, write_kwargs = utils._get_write_function_and_kwargs(tdf, path, f_or_d,
+                                                                            case_space_table_names=False)
             write_func(dat, path, **write_kwargs)
             dat_1 = utils._get_dat_object(tdf, "create_tic_dat", path, f_or_d, False)
             self.assertTrue(tdf._same_data(dat, dat_1))

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -1456,6 +1456,11 @@ class TestUtils(unittest.TestCase):
         postgresql.stop()
         sys.modules.pop(funky_diet.solve.__module__)
 
+    def testThirtyOne(self):
+        slicer  = utils.Slicer(itertools.product([1, 2], [(1, 2, 3), (2, 3, 4)], [4, 5, 6]))
+        self.assertTrue(set(slicer.slice('*', '*', 5)) ==
+                        {(1, (2, 3, 4), 5), (2, (2, 3, 4), 5), (1, (1, 2, 3), 5), (2, (1, 2, 3), 5)})
+        self.assertTrue(set(slicer.slice('*', (2, 3, 4), 5)) =={(1, (2, 3, 4), 5), (2, (2, 3, 4), 5)})
 _scratchDir = TestUtils.__name__ + "_scratch"
 
 

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -604,7 +604,6 @@ class TicDatFactory(freezable_factory(object, "_isFrozen", {"opl_prepend", "ampl
                 self._default_values[tbl][fld] = 0
         self._data_types = clt.defaultdict(dict)
         self._data_row_predicates = clt.defaultdict(dict)
-        self._data_row_predicate_advanced_settings = clt.defaultdict(dict)
         self._generator_tables = []
         self._foreign_keys = clt.defaultdict(set)
         self.all_tables = frozenset(init_fields)

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -484,7 +484,11 @@ class TicDatFactory(freezable_factory(object, "_isFrozen", {"opl_prepend", "ampl
                    "%s does not refer to one of %s 's fields"%(k, native_table))
             verify(v in self._allFields(foreign_table),
                    "%s does not refer to one of %s 's fields"%(v, foreign_table))
+        if utils.does_new_fk_complete_circle(native_table, foreign_table, self):
+            print(f"*** A circular foreign key relationship will be creating by adding the {native_table} to " +
+                  f"{foreign_table} connection")
         self._foreign_keys[native_table, foreign_table].add(tuple(_mappings.items()))
+
     def _simple_fk(self, ftbl, fk):
         assert ftbl in self.all_tables
         ftbl_pks = set(self.primary_key_fields.get(ftbl,()))

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -1705,7 +1705,9 @@ class TicDatFactory(freezable_factory(object, "_isFrozen", {"opl_prepend", "ampl
                         predicate_kwargs_maker_results[rpi.predicate_kwargs_maker] = _predicate_kwargs
                     predicate_kwargs = predicate_kwargs_maker_results[rpi.predicate_kwargs_maker]
                 if not isinstance(predicate_kwargs, dict):
-                    rtn[tbl, pn] = PKEM('*', str(predicate_kwargs))
+                    rtn[tbl, pn] = PKEM('*', predicate_kwargs
+                                        if (isinstance(predicate_kwargs, str) and "Exception<" in predicate_kwargs)
+                                        else f"predicate_kwargs_maker failed to return a dict")
                 else:
                     if rpi.predicate_failure_response == "Boolean":
                         def _p(row):

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -872,8 +872,9 @@ class TicDatFactory(freezable_factory(object, "_isFrozen", {"opl_prepend", "ampl
         assert t in self.all_tables
         if t == "parameters": # infinity flagging doesn't apply to parameters table, see set_infinity_flag __doc__
             return x
-        if self._data_types.get(t, {}).get(f) and self.data_types[t][f].datetime and utils.stringish(x) and \
-           utils.dateutil_adjuster(x) is not None:
+        if self._data_types.get(t, {}).get(f) and self.data_types[t][f].datetime and \
+                (not (x is None or (utils.pd and utils.pd.isnull(x)))) and \
+                utils.dateutil_adjuster(x) is not None:
             return utils.dateutil_adjuster(x)
         if utils.numericish(self.infinity_io_flag) and utils.numericish(x):
             if x >= self.infinity_io_flag:

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -872,7 +872,8 @@ class TicDatFactory(freezable_factory(object, "_isFrozen", {"opl_prepend", "ampl
         assert t in self.all_tables
         if t == "parameters": # infinity flagging doesn't apply to parameters table, see set_infinity_flag __doc__
             return x
-        if self._data_types.get(t, {}).get(f) and self.data_types[t][f].datetime and \
+        # SPEED IS IMPORTANT HERE!!!!
+        if self._data_types.get(t, {}).get(f) and self._data_types[t][f].datetime and \
                 (not (x is None or (utils.pd and utils.pd.isnull(x)))) and \
                 utils.dateutil_adjuster(x) is not None:
             return utils.dateutil_adjuster(x)

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -1072,3 +1072,17 @@ def nearly_same(x1, x2, epsilon) :
 
 RowPredicateInfo = namedtuple("RowPredicateInfo", ["predicate", "predicate_kwargs_maker",
                                                    "predicate_failure_response"])
+
+def does_new_fk_complete_circle(native_tbl, foreign_tbl, tdf):
+    fks = defaultdict(set)
+    for fk in tdf.foreign_keys:
+        fks[fk.native_table].add(fk)
+    rtn = []
+    def process_table(t, already_seen):
+        if t == native_tbl:
+            rtn[:] = [True]
+        elif t not in already_seen:
+            for fk in fks.get(t, ()):
+                process_table(fk.foreign_table, already_seen + [t])
+    process_table(foreign_tbl, [])
+    return bool(rtn)

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -678,7 +678,7 @@ class Slicer(object):
             verify(not any("*" in _ for _ in self._indicies),
                    "The '*' character cannot itself be used as an index")
         self._gu = None
-        if gu:
+        if gu and not any(any(map(containerish, _)) for _ in self._indicies):
             self._gu = gu.tuplelist(self._indicies)
             self._indicies = None
         self.clear()

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -19,8 +19,9 @@ except:
 try:
     import pandas as pd
     from pandas import DataFrame
+    import numpy
 except:
-    pd = DataFrame =  None
+    pd = DataFrame = numpy = None
 
 try:
     import ocp_ticdat_drm as drm
@@ -912,7 +913,7 @@ class Sloc(object):
         except Exception as e:
             if containerish(key) and any(isinstance(k, slice) and
                                          (k.start == k.step == k.stop == None) for k in key):
-                return pd.Series([])
+                return pd.Series([], dtype=numpy.float64)
             raise e
     @staticmethod
     def add_sloc(s):

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -667,6 +667,9 @@ class Slicer(object):
         :param iter_of_iters An iterable of iterables. Usually a list of lists, or a list
         of tuples. Each inner iterable must be the same size. The "*" string has a special
         flag meaning and cannot be a member of any of the inner iterables.
+        Slicer is fairly similar to gurobipy.tuplelist, and will try to use tuplelist for improved performance
+        whenever possible. One key difference is Slicer can accommodate tuples that themselves contain tuples (or
+        really any hashable) wherease tuplelist should only be used with tuples that themselves contain only primitives.
         """
         verify(hasattr(iter_of_iters, "__iter__"), "need an iterator of iterators")
         copied = tuple(iter_of_iters)
@@ -688,7 +691,7 @@ class Slicer(object):
         Perform a multi-index slice. (Not to be confused with the native Python slice)
         :param *args a series of index values or '*'. The latter means 'match every value'
         :return: a list of tuples which match  args.
-        :caveat will run faster if gurobipy is available
+        :caveat will run faster if gurobipy is available and tuplelist can accommodate the interior iterables
         """
         if not (self._indicies or self._gu):
             return []

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -373,6 +373,9 @@ def standard_main(input_schema, solution_schema, solve, case_space_table_names=F
                                                               case_space_table_names=case_space_table_names)
     if not action_name:
         sln = solve(dat)
+        verify(not (sln is not None and safe_apply(bool)(sln) is None),
+               "The solve (or action) function should return either a TicDat/PanDat object (for success), " +
+               "or something falsey (to indicate failure)")
         if sln:
             print("%s output %s %s"%("Overwriting" if os.path.exists(output_file) else "Creating",
                                      file_or_dir(output_file), output_file))


### PR DESCRIPTION
- Better error messages if solve/action returned objects not bool-able (for ex. `DataFrame` returned by accident)
- better performance by fixing some dump time wasting stuff on data ingestion and pre-writing
- `standard_main` has `case_space_table_names` argument
- max_failures with integrity check failures - allow integrity checker to fast-fail on dirty data.
- `ticdat.Slicer` very corner case bug resolved 
- minor flaw in `good_tic_dat_object`
- PostGres date support  
 
