### PR TITLE
Trailing all nones

### DIFF
--- a/ticdat/pandatfactory.py
+++ b/ticdat/pandatfactory.py
@@ -377,13 +377,16 @@ class PanDatFactory(object):
             for f in self.primary_key_fields.get(t, ()) + self.data_fields.get(t, ()):
                 if utils.numericish(self.infinity_io_flag):
                     fixme = apply(df, lambda row: utils.numericish(row[f]) and row[f] >= self.infinity_io_flag)
-                    df.loc[fixme, f] = self.infinity_io_flag
+                    if fixme.any():
+                        df.loc[fixme, f] = self.infinity_io_flag
                     fixme = apply(df, lambda row: utils.numericish(row[f]) and row[f] <= -self.infinity_io_flag)
-                    df.loc[fixme, f] = -self.infinity_io_flag
+                    if fixme.any():
+                        df.loc[fixme, f] = -self.infinity_io_flag
                 elif utils.numericish(self._none_as_infinity_bias(t, f)):
                     assert self.infinity_io_flag is None
                     fixme = apply(df, lambda row: row[f] == float("inf") * self._none_as_infinity_bias(t, f))
-                    df.loc[fixme, f] = None
+                    if fixme.any():
+                        df.loc[fixme, f] = None
         return rtn
     def set_data_type(self, table, field, number_allowed = True,
                       inclusive_min = True, inclusive_max = False, min = 0, max = float("inf"),

--- a/ticdat/pandatfactory.py
+++ b/ticdat/pandatfactory.py
@@ -210,7 +210,7 @@ class PanDatFactory(object):
     def set_xlsx_trailing_empty_rows(self, value):
         """
         Set the xlsx_trailing_empty_rows for the PanDatFactory. Choices are:
-        --> 'prune' : (the default) when reading an xlsx/xlsm file, look for trailing all pd.isnan rows in each table,
+        --> 'prune' : (the default) when reading an xlsx/xlsm file, look for trailing all pd.isnull rows in each table,
                       and prune them
         --> 'ignore': retain such rows
         With the move to openpyxl for xlsx/xlsm file reading, its more likely that Excel users accidentally creating

--- a/ticdat/pandatio.py
+++ b/ticdat/pandatio.py
@@ -47,10 +47,6 @@ def _clean_pandat_creator(pdf, df_dict, push_parameters_to_be_valid=True, json_r
     return pdf._general_post_read_adjustment(pandat, json_read=json_read,
                                              push_parameters_to_be_valid=push_parameters_to_be_valid)
 
-def _remove_trailing_all_nan(df):
-    print("NOT DOING YET!")
-    return df
-
 class JsonPanFactory(freezable_factory(object, "_isFrozen")):
     """
     Primary class for reading/writing json data with PanDat objects.
@@ -517,8 +513,9 @@ class XlsPanFactory(freezable_factory(object, "_isFrozen")):
         xl.close()
         rtn = _clean_pandat_creator(self.pan_dat_factory, rtn, print_missing_tables=True)
         if self.pan_dat_factory.xlsx_trailing_empty_rows == "prune":
+            from ticdat.pandatfactory import remove_trailing_all_nan
             for t in self.pan_dat_factory.all_tables:
-                setattr(rtn, t, _remove_trailing_all_nan(getattr(rtn, t)))
+                setattr(rtn, t, remove_trailing_all_nan(getattr(rtn, t)))
         return rtn
 
 

--- a/ticdat/pandatio.py
+++ b/ticdat/pandatio.py
@@ -557,3 +557,4 @@ class XlsPanFactory(freezable_factory(object, "_isFrozen")):
             getattr(pan_dat, t).to_excel(writer, case_space_to_pretty(t) if case_space_sheet_names else t,
                                          index=False)
         writer.save()
+        writer.close()

--- a/ticdat/testing/testpandat_io.py
+++ b/ticdat/testing/testpandat_io.py
@@ -76,7 +76,7 @@ def create_inputset_mock_with_active_hack(tdf, dat, hack_table_names=False):
             return rtn
     return RtnObject()
 
-#uncomment decorator to drop into debugger for assertTrue, assertFalse failures
+#uncomment decorator to drop into debugger for assertTrue, assertFalse failures (also hides a bunch of warnings)
 #@fail_to_debugger
 class TestIO(unittest.TestCase):
     can_run = False
@@ -274,7 +274,6 @@ class TestIO(unittest.TestCase):
             self.assertFalse(pdf._same_data(dat_inf, dat_1))
             dat_inf = make_dat([[float("-inf"), 100], [200, 109], [0, 300], [300, -float("inf")], [400, 0]])
             self.assertTrue(pdf._same_data(dat_inf, dat_1))
-
 
     def testXlsSpacey(self):
         if not self.can_run:

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -1146,6 +1146,7 @@ class TestUtils(unittest.TestCase):
             new_sch = tdf.schema(include_ancillary_info=True)
             self.assertFalse(new_sch.pop("parameters"))
             self.assertTrue(new_sch.pop("infinity_io_flag") == "N/A")
+            self.assertTrue(new_sch.pop("xlsx_trailing_empty_rows") == "prune")
             new_sch = json.loads(json.dumps(new_sch))
             new_sch["foreign_keys"] = sorted(new_sch["foreign_keys"])
             self.assertTrue(new_sch == simple_sch)
@@ -1338,7 +1339,7 @@ class TestUtils(unittest.TestCase):
                                                 'Max Nutrition': [True, True, True, 0, inf, False, [], False, False]},
                                  'nutrition_quantities': {'Quantity': [True, True, False, 0, inf, False, [], False,
                                                                        False]}},
-                 'parameters': {}, 'infinity_io_flag': 'N/A'})
+                 'parameters': {}, 'infinity_io_flag': 'N/A', "xlsx_trailing_empty_rows": "prune"})
 
     def testTwentyNine(self):
         data_path = os.path.join(_scratchDir, "custom_module_three")

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -120,7 +120,7 @@ def clone_a_anchillary_info_schema(schema, table_restrictions):
         elif k == "parameters":
             rtn[k] = v if k in table_restrictions else {}
         else:
-            assert k == "infinity_io_flag", f"{k} is unpexted part of schema"
+            assert k in {"infinity_io_flag", "xlsx_trailing_empty_rows"}, f"{k} is unexpected part of schema"
             rtn[k] = v
     return rtn
 


### PR DESCRIPTION
The `openpyxl` requirement for newer versions results in the reading of trailing all None columns that were previously ignored.