### PR TITLE
Cleaner json 

### DIFF
--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -10,11 +10,12 @@ The ticDat library is distributed under the BSD2 open source license.
 
 from ticdat.ticdatfactory import TicDatFactory, freeze_me
 from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
-                         gurobi_env, ampl_format, verify, dat_restricted, sln_restricted
+                         gurobi_env, ampl_format, verify, dat_restricted, sln_restricted, \
+                         faster_df_apply
 from ticdat.opl import opl_run, create_opl_mod_text, create_opl_mod_output_text
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
 __version__ = '0.2.21'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "opl_run", "create_opl_mod_text", "create_opl_mod_output_text", "ampl_format",
-           "gurobi_env", "verify", "dat_restricted", "sln_restricted"]
+           "gurobi_env", "verify", "dat_restricted", "sln_restricted", "faster_df_apply"]

--- a/ticdat/pandatio.py
+++ b/ticdat/pandatio.py
@@ -140,10 +140,13 @@ class JsonPanFactory(freezable_factory(object, "_isFrozen")):
             else:
                 rtn.pop(table)
         return rtn
-    def write_file(self, pan_dat, json_file_path, case_space_table_names=False, orient='split',
+    def write_file_pd(self, pan_dat, json_file_path, case_space_table_names=False, orient='split',
                    index=False, indent=2, sort_keys=False, **kwargs):
         """
-        write the PanDat data to a json file (or json string)
+        write the PanDat data to a json file (or json string).
+        Use this routine to write json text that is consistent with what pandas.to_json.
+        The list-of-lists format is created with write_file. In older ticdat releases, write_file
+        implemented the functionaltiy now provided with write_file_pd.
 
         :param pan_dat: the PanDat object to write
 

--- a/ticdat/pandatio.py
+++ b/ticdat/pandatio.py
@@ -143,9 +143,15 @@ class JsonPanFactory(freezable_factory(object, "_isFrozen")):
         return rtn
     def write_file(self, pan_dat, json_file_path):
         """
-        :param pan_dat:
-        :param json_file_path:
-        :return:
+        Write the PanDat data to a json file (or json string). Writes each table as a list-of-lists.
+        See write_file_pd for other formats.
+
+        :param pan_dat: the PanDat object to write
+
+        :param json_file_path: the json file into which the data is to be written. If falsey, will return a
+                               JSON string
+
+        :return: A JSON string if json_file_path is falsey, otherwise None
         """
         msg = []
         verify(self.pan_dat_factory.good_pan_dat_object(pan_dat, msg.append),

--- a/ticdat/testing/testpandat_io.py
+++ b/ticdat/testing/testpandat_io.py
@@ -387,8 +387,12 @@ class TestIO(unittest.TestCase):
         panDat3.foods.drop("extra", axis=1, inplace=True)
         self.assertTrue(pdf._same_data(panDat, panDat3, epsilon=1e-5))
 
-        # the list-of-lists json doesn't add columns, it just throws an error - test this and verify
-        # that TicDatFactory is same
+        ex = []
+        try:
+            pdf3.json.create_pan_dat(pdf.json.write_file(panDat, ""), fill_missing_fields=True)
+        except utils.TicDatError as e:
+            ex.append(e)
+        self.assertTrue(ex)
 
     def testSqlSimple(self):
         if not self.can_run:

--- a/ticdat/testing/testpandat_io.py
+++ b/ticdat/testing/testpandat_io.py
@@ -150,7 +150,7 @@ class TestIO(unittest.TestCase):
         core_path = os.path.join(_scratchDir, "diet_with_inf_flagging")
         diet_pdf.sql.write_file(dat, core_path+".db")
         diet_pdf.csv.write_directory(dat, core_path+"_csv")
-        diet_pdf.json.write_file(dat, core_path+".json")
+        diet_pdf.json.write_file_pd(dat, core_path+".json")
         diet_pdf.xls.write_file(dat, core_path+".xlsx")
         for attr, f in [["sql", core_path+".db"], ["csv", core_path+"_csv"], ["json", core_path+".json"],
                         ["xls", core_path+".xlsx"]]:
@@ -172,9 +172,10 @@ class TestIO(unittest.TestCase):
         pdf_1 = PanDatFactory(this = [["Something"],["Another"]])
         pdf_2 = PanDatFactory(**dict(pdf_1.schema(), that=[["What", "Ever"],[]]))
         dat = pdf_1.PanDat(this={"Something": ["a", "b", "c"], "Another": [2, 3, 5]})
-        for attr, path in [["sql", core_path+".db"], ["csv", core_path+"_csv"], ["json", core_path+".json"],
-                           ["xls", core_path+".xlsx"]]:
-            func = "write_directory" if attr == "csv" else "write_file"
+        for attr, path, func in [["sql", core_path+".db", "write_file"],
+                           ["csv", core_path+"_csv", "write_directory"],
+                           ["json", core_path+".json", "write_file_pd"],
+                           ["xls", core_path+".xlsx", "write_file"]]:
             getattr(getattr(pdf_1, attr), func)(dat, path)
             dat_1 = getattr(pdf_2, attr).create_pan_dat(path)
             self.assertTrue(pdf_1._same_data(dat, dat_1))
@@ -195,9 +196,10 @@ class TestIO(unittest.TestCase):
         dat = TicDatFactory(**pdf.schema()).copy_to_pandas(dat, drop_pk_columns=False)
         self.assertFalse(pdf.find_data_type_failures(dat) or pdf.find_data_row_failures(dat))
 
-        for attr, path in [["csv", core_path+"_csv"], ["xls", core_path+".xlsx"], ["sql", core_path+".db"],
-                           ["json", core_path+".json"]]:
-            func = "write_directory" if attr == "csv" else "write_file"
+        for attr, path, func in [["sql", core_path+".db", "write_file"],
+                           ["csv", core_path+"_csv", "write_directory"],
+                           ["json", core_path+".json", "write_file_pd"],
+                           ["xls", core_path+".xlsx", "write_file"]]:
             getattr(getattr(pdf, attr), func)(dat, path)
             dat_1 = getattr(pdf, attr).create_pan_dat(path)
             self.assertFalse(pdf._same_data(dat, dat_1))
@@ -232,18 +234,20 @@ class TestIO(unittest.TestCase):
         pdf.add_parameter("Different", 'boo', strings_allowed='*', number_allowed=False)
         dat = TicDatFactory(**pdf.schema()).TicDat(parameters = [["Something",float("inf")], ["Different", "inf"]])
         dat = TicDatFactory(**pdf.schema()).copy_to_pandas(dat, drop_pk_columns=False)
-        for attr, path in [["sql", core_path+".db"], ["csv", core_path+"_csv"], ["json", core_path+".json"],
-                           ["xls", core_path+".xlsx"]]:
-            func = "write_directory" if attr == "csv" else "write_file"
+        for attr, path, func in [["sql", core_path+".db", "write_file"],
+                           ["csv", core_path+"_csv", "write_directory"],
+                           ["json", core_path+".json", "write_file_pd"],
+                           ["xls", core_path+".xlsx", "write_file"]]:
             getattr(getattr(pdf, attr), func)(dat, path)
             dat_1 = getattr(pdf, attr).create_pan_dat(path)
             self.assertTrue(pdf._same_data(dat, dat_1))
         core_path = os.path.join(_scratchDir, "parameters_two")
         dat = TicDatFactory(**pdf.schema()).TicDat(parameters = [["Something",float("inf")], ["Different", "05701"]])
         dat = TicDatFactory(**pdf.schema()).copy_to_pandas(dat, drop_pk_columns=False)
-        for attr, path in [["sql", core_path+".db"], ["csv", core_path+"_csv"], ["xls", core_path+".xlsx"],
-                           ["json", core_path + ".json"]]:
-            func = "write_directory" if attr == "csv" else "write_file"
+        for attr, path, func in [["sql", core_path+".db", "write_file"],
+                           ["csv", core_path+"_csv", "write_directory"],
+                           ["json", core_path+".json", "write_file_pd"],
+                           ["xls", core_path+".xlsx", "write_file"]]:
             getattr(getattr(pdf, attr), func)(dat, path)
             dat_1 = getattr(pdf, attr).create_pan_dat(path)
             self.assertTrue(pdf._same_data(dat, dat_1))
@@ -258,9 +262,10 @@ class TestIO(unittest.TestCase):
             return tdf.copy_to_pandas(tdf.TicDat(table = l), drop_pk_columns=False)
         dat = make_dat([[None, 100], [200, 109], [0, 300], [300, None], [400, 0]])
         core_path = os.path.join(_scratchDir, "non_inf_flagging")
-        for attr, path in [["sql", core_path+".db"], ["csv", core_path+"_csv"], ["json", core_path+".json"],
-                           ["xls", core_path+".xlsx"]]:
-            func = "write_directory" if attr == "csv" else "write_file"
+        for attr, path, func in [["sql", core_path+".db", "write_file"],
+                                 ["csv", core_path+"_csv", "write_directory"],
+                                 ["json", core_path+".json", "write_file_pd"],
+                                 ["xls", core_path+".xlsx", "write_file"]]:
             getattr(getattr(pdf, attr), func)(dat, path)
             dat_1 = getattr(pdf, attr).create_pan_dat(path)
             _ = PanDatFactory(table=[[], ["field one", "field two"]])
@@ -329,7 +334,7 @@ class TestIO(unittest.TestCase):
         self.assertTrue("missing" in ex and "extra" in ex)
         ex = self.firesException(lambda : pdf2.csv.create_pan_dat(csvDirPath))
         self.assertTrue("missing" in ex and "extra" in ex)
-        ex = self.firesException(lambda : pdf2.json.create_pan_dat(pdf.json.write_file(panDat, "")))
+        ex = self.firesException(lambda : pdf2.json.create_pan_dat(pdf.json.write_file_pd(panDat, "")))
         self.assertTrue("missing" in ex and "extra" in ex)
 
         panDat2 = pdf2.sql.create_pan_dat(sqlFilePath, fill_missing_fields=True)
@@ -347,7 +352,7 @@ class TestIO(unittest.TestCase):
         panDat2.foods.drop("extra", axis=1, inplace=True)
         self.assertTrue(pdf._same_data(panDat, panDat2))
 
-        panDat2 = pdf2.json.create_pan_dat(pdf.json.write_file(panDat, ""), fill_missing_fields=True)
+        panDat2 = pdf2.json.create_pan_dat(pdf.json.write_file_pd(panDat, ""), fill_missing_fields=True)
         self.assertTrue(set(panDat2.foods["extra"]) == {0})
         panDat2.foods.drop("extra", axis=1, inplace=True)
         self.assertTrue(pdf._same_data(panDat, panDat2, epsilon=1e-5))
@@ -369,7 +374,7 @@ class TestIO(unittest.TestCase):
         panDat3.foods.drop("extra", axis=1, inplace=True)
         self.assertTrue(pdf._same_data(panDat, panDat3))
 
-        panDat3 = pdf3.json.create_pan_dat(pdf.json.write_file(panDat, ""), fill_missing_fields=True)
+        panDat3 = pdf3.json.create_pan_dat(pdf.json.write_file_pd(panDat, ""), fill_missing_fields=True)
         self.assertTrue(set(panDat3.foods["extra"]) == {13})
         panDat3.foods.drop("extra", axis=1, inplace=True)
         self.assertTrue(pdf._same_data(panDat, panDat3, epsilon=1e-5))
@@ -566,11 +571,11 @@ class TestIO(unittest.TestCase):
         ticDat = tdf.freeze_me(tdf.TicDat(**{t:getattr(dietData(),t) for t in tdf.primary_key_fields}))
         panDat = pan_dat_maker(dietSchema(), ticDat)
         filePath = os.path.join(_scratchDir, "diet.json")
-        pdf.json.write_file(panDat, filePath)
+        pdf.json.write_file_pd(panDat, filePath)
         panDat2 = pdf.json.create_pan_dat(filePath)
         self.assertTrue(pdf._same_data(panDat, panDat2, epsilon=1e-5))
         pdf2 = PanDatFactory(**{t:'*' for t in pdf.all_tables})
-        pdf2.json.write_file(panDat, filePath)
+        pdf2.json.write_file_pd(panDat, filePath)
         panDat2 = pdf2.json.create_pan_dat(filePath)
         self.assertTrue(pdf._same_data(panDat, panDat2, epsilon=1e-5))
 
@@ -587,12 +592,12 @@ class TestIO(unittest.TestCase):
         ticDat = tdf.freeze_me(tdf.TicDat(**{t:getattr(netflowData(),t) for t in tdf.primary_key_fields}))
         panDat = pan_dat_maker(netflowSchema(), ticDat)
         filePath = os.path.join(_scratchDir, "netflow.json")
-        pdf.json.write_file(panDat, filePath)
+        pdf.json.write_file_pd(panDat, filePath)
         panDat2 = pdf.json.create_pan_dat(filePath)
         self.assertTrue(pdf._same_data(panDat, panDat2, epsilon=1e-5))
-        panDat3 = pdf.json.create_pan_dat(pdf.json.write_file(panDat, ""))
+        panDat3 = pdf.json.create_pan_dat(pdf.json.write_file_pd(panDat, ""))
         self.assertTrue(pdf._same_data(panDat, panDat3))
-        dicted = json.loads(pdf.json.write_file(panDat, ""))
+        dicted = json.loads(pdf.json.write_file_pd(panDat, ""))
         panDat4 = pdf.PanDat(**dicted)
         self.assertTrue(pdf._same_data(panDat, panDat4))
         pdf2 = PanDatFactory(**{t:'*' for t in pdf.all_tables})
@@ -605,14 +610,14 @@ class TestIO(unittest.TestCase):
         ticDat = tdf.freeze_me(tdf.TicDat(**{t:getattr(dietData(),t) for t in tdf.primary_key_fields}))
         panDat = pan_dat_maker(dietSchema(), ticDat)
         filePath = os.path.join(_scratchDir, "diet.json")
-        pdf.json.write_file(panDat, filePath, orient='columns', index=True)
+        pdf.json.write_file_pd(panDat, filePath, orient='columns', index=True)
         # the following doesn't generate a TicDatError, which is fine
         self.assertTrue(firesException(lambda : pdf.json.create_pan_dat(filePath)))
         panDat2 = pdf.json.create_pan_dat(filePath, orient='columns')
         self.assertTrue(pdf._same_data(panDat, panDat2, epsilon=1e-5))
-        panDat3 = pdf.json.create_pan_dat(pdf.json.write_file(panDat, "", orient='columns'), orient="columns")
+        panDat3 = pdf.json.create_pan_dat(pdf.json.write_file_pd(panDat, "", orient='columns'), orient="columns")
         self.assertTrue(pdf._same_data(panDat, panDat3, epsilon=1e-5))
-        dicted = json.loads(pdf.json.write_file(panDat, "", orient='columns'))
+        dicted = json.loads(pdf.json.write_file_pd(panDat, "", orient='columns'))
         panDat4 = pdf.PanDat(**dicted)
         self.assertTrue(pdf._same_data(panDat, panDat4, epsilon=1e-5))
 
@@ -624,7 +629,7 @@ class TestIO(unittest.TestCase):
         ticDat = tdf.freeze_me(tdf.TicDat(**{t: getattr(dietData(),t) for t in tdf.primary_key_fields}))
         panDat = pan_dat_maker(dietSchema(), ticDat)
         filePath = os.path.join(_scratchDir, "diet_cross.json")
-        pdf.json.write_file(panDat, filePath)
+        pdf.json.write_file_pd(panDat, filePath)
         ticDat2 = tdf.json.create_tic_dat(filePath, from_pandas=True)
         self.assertTrue(tdf._same_data(ticDat, ticDat2, epsilon=0.0001))
         tdf.json.write_file(ticDat, filePath, allow_overwrite=True, to_pandas=True)
@@ -641,10 +646,10 @@ class TestIO(unittest.TestCase):
         panDat = pan_dat_maker(spacesSchema(), ticDat)
         ext = ".json"
         filePath = os.path.join(_scratchDir, "spaces_2%s" % ext)
-        pdf.json.write_file(panDat, filePath, case_space_table_names=True)
+        pdf.json.write_file_pd(panDat, filePath, case_space_table_names=True)
         panDat2 = pdf.json.create_pan_dat(filePath)
         self.assertTrue(pdf._same_data(panDat, panDat2))
-        panDat3 = pdf.json.create_pan_dat(pdf.json.write_file(panDat, "", case_space_table_names=True))
+        panDat3 = pdf.json.create_pan_dat(pdf.json.write_file_pd(panDat, "", case_space_table_names=True))
         self.assertTrue(pdf._same_data(panDat, panDat3))
 
 
@@ -653,13 +658,13 @@ class TestIO(unittest.TestCase):
         ticDat = tdf.freeze_me(tdf.TicDat(**{t:getattr(netflowData(),t) for t in tdf.primary_key_fields}))
         panDat = pan_dat_maker(netflowSchema(), ticDat)
         filePath = os.path.join(_scratchDir, "spaces_2_2%s" % ext)
-        pdf.json.write_file(panDat, filePath, case_space_table_names=True)
+        pdf.json.write_file_pd(panDat, filePath, case_space_table_names=True)
         panDat2 = pdf.json.create_pan_dat(filePath)
         self.assertTrue(pdf._same_data(panDat, panDat2))
-        panDat3 = pdf.json.create_pan_dat(pdf.json.write_file(panDat, "", case_space_table_names=True))
+        panDat3 = pdf.json.create_pan_dat(pdf.json.write_file_pd(panDat, "", case_space_table_names=True))
         self.assertTrue(pdf._same_data(panDat, panDat3))
 
-        dicted = json.loads(pdf.json.write_file(panDat, "", orient='columns'))
+        dicted = json.loads(pdf.json.write_file_pd(panDat, "", orient='columns'))
         panDat4 = pdf.PanDat(**dicted)
         self.assertTrue(pdf._same_data(panDat, panDat4, epsilon=1e-5))
 

--- a/ticdat/testing/testpandat_io.py
+++ b/ticdat/testing/testpandat_io.py
@@ -387,11 +387,8 @@ class TestIO(unittest.TestCase):
         panDat3.foods.drop("extra", axis=1, inplace=True)
         self.assertTrue(pdf._same_data(panDat, panDat3, epsilon=1e-5))
 
-        panDat3 = pdf3.json.create_pan_dat(pdf.json.write_file(panDat, ""), fill_missing_fields=True)
-        self.assertTrue(set(panDat3.foods["extra"]) == {13})
-        panDat3.foods.drop("extra", axis=1, inplace=True)
-        self.assertTrue(pdf._same_data(panDat, panDat3, epsilon=1e-5))
-
+        # the list-of-lists json doesn't add columns, it just throws an error - test this and verify
+        # that TicDatFactory is same
 
     def testSqlSimple(self):
         if not self.can_run:
@@ -588,7 +585,7 @@ class TestIO(unittest.TestCase):
             getattr(pdf.json, func)(panDat, filePath)
             panDat2 = pdf.json.create_pan_dat(filePath)
             self.assertTrue(pdf._same_data(panDat, panDat2, epsilon=1e-5))
-            pdf2 = PanDatFactory(**{t:'*' for t in pdf.all_tables})
+            pdf2 = PanDatFactory(**{t:'*' for t in pdf.all_tables}) if func == "write_file_pd" else pdf
             getattr(pdf.json, func)(panDat, filePath)
             panDat2 = pdf2.json.create_pan_dat(filePath)
             self.assertTrue(pdf._same_data(panDat, panDat2, epsilon=1e-5))
@@ -614,7 +611,7 @@ class TestIO(unittest.TestCase):
             dicted = json.loads(getattr(pdf.json, func)(panDat, ""))
             panDat4 = pdf.PanDat(**dicted)
             self.assertTrue(pdf._same_data(panDat, panDat4))
-            pdf2 = PanDatFactory(**{t:'*' for t in pdf.all_tables})
+            pdf2 = PanDatFactory(**{t:'*' for t in pdf.all_tables}) if func == "write_file_pd" else pdf
             panDat5 = pdf2.PanDat(**dicted)
             self.assertTrue(pdf._same_data(panDat, panDat5))
 

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -30,6 +30,31 @@ except:
 import inspect
 
 def faster_df_apply(df, func, trip_wire_check=None):
+    """
+    pandas.DataFrame.apply is rarely used because it is slow. It is slow because it creates a Series for each row
+    of the DataFrame, and passes this Series to the function. faster_df_apply creates a dict for each row of the
+    DataFrame instead, and as a result is **much** faster.
+
+    See https://bit.ly/3xnLFld.
+
+    It's certainly possible newer versions of pandas will implement a more performant DataFrame.apply. The broader
+    point is, row-wise apply should not be discarded wholesale for performance reasons, as DataFrame.itertuples
+    is reasonably fast
+
+    :param df: a DataFrame
+
+    :param func: a function to apply to each row of the DataFrame. The function should accept a fieldname->data
+                 dictionary as argument. func will be applied to each row of the DataFrame
+
+    :param trip_wire_check: optional. If provided, a function that will be passed each result returned by func.
+                                      trip_wire_check can either return falsey, or a replacement to func to be applied
+                                      to the remainder of the DataFrame
+
+    :return: a pandas Series with the same index as df and the values of calling func on each row dict.
+    """
+    verify(DataFrame and isinstance(df, DataFrame), "df argument needs to be a DataFrame")
+    verify(callable(func), "func needs to be a function")
+    verify(not trip_wire_check or callable(trip_wire_check), "trip_wire_check needs to None, or a function")
     cols = list(df.columns)
     data, index = [], []
     for row in df.itertuples(index=True):


### PR DESCRIPTION
Partially addresses issue #146 by making "list of lists" the standard json written file for `PanDatFactory`.
Also cleaned up a double warning.