### PR TITLE
Fixes minor bug in write_schema

### DIFF
--- a/examples/datetime/simple_datetime_solver.py
+++ b/examples/datetime/simple_datetime_solver.py
@@ -16,6 +16,7 @@ input_schema = PanDatFactory(parameters=[["Name"],["Value"]],
                              orders=[["Name"], ["Deliver By"]])
 input_schema.set_data_type("orders", "Deliver By", datetime=True)
 input_schema.add_parameter("Start Of Model", "Jan 1 2019 8 AM", datetime=True)
+input_schema.set_default_value("orders", "Deliver By", "Jan 1 2019 1 PM")
 # ---------------------------------------------------------------------------------
 
 # ------------------------ define the output schema -------------------------------

--- a/ticdat/pgtd.py
+++ b/ticdat/pgtd.py
@@ -158,6 +158,8 @@ class _PostgresFactory(freezable_factory(object, "_isFrozen"),):
             return fld_type.nullable
 
         def default_sql_str(t, f):
+            if forced_field_types.get((t, f)) == "text" and stringish(self.tdf.default_values[t][f]):
+                return f" DEFAULT {db_default(t, f)}"
             fld_type = self.tdf.data_types.get(t, {}).get(f)
             if (fld_type and fld_type.datetime) or get_fld_type(t, f, '') == "bytea":
                 return ""

--- a/ticdat/pgtd.py
+++ b/ticdat/pgtd.py
@@ -210,6 +210,9 @@ class _PostgresFactory(freezable_factory(object, "_isFrozen"),):
             for t, dts in self.tdf.data_types.items():
                 for f, dt in dts.items():
                     tdf.set_data_type(t, f, *dt)
+            for t, dfvs in self.tdf.default_values.items():
+                for f, dfv in dfvs.items():
+                    tdf.set_default_value(t, f, dfv)
             forced_field_types_ = {(t, f): "text" for t, (pks, dfs) in self.tdf.schema().items() for f in pks
                        if f not in tdf.data_types.get(t, {})}
             forced_field_types_.update(forced_field_types)


### PR DESCRIPTION
Relevant section of docstring from `pgtd.py` quoted below.

> :param  include_ancillary_info : boolean. If False, no primary key or foreign key info will be written

So the default value should be written to the PG DB even when the `include_ancillary_info` is False. 

Also changed `write_schema` so that a `datetime` data typed column with a string default and a text PG column type will retain the default. 