### PR TITLE
0.2.24 release

### DIFF
--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -14,7 +14,7 @@ from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
 from ticdat.opl import opl_run, create_opl_mod_text, create_opl_mod_output_text
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
-__version__ = '0.2.23'
+__version__ = '0.2.24'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "opl_run", "create_opl_mod_text", "create_opl_mod_output_text", "ampl_format",
            "gurobi_env", "verify", "faster_df_apply"]

--- a/ticdat/pandatfactory.py
+++ b/ticdat/pandatfactory.py
@@ -607,9 +607,9 @@ class PanDatFactory(object):
 
         !!! NB!!!!
 
-        **pandas will render None as nan.**
+        **pandas will typically render NULL as nan. In rare cases, it uses None.**
 
-        **Don't check for None in your predicate functions, use pandas.isnull instead**
+        **Don't check for None (or nan) in your predicate functions. Use pandas.isnull**
 
         !!!!!!!!!!
 

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -1595,6 +1595,15 @@ class TestUtils(unittest.TestCase):
                     self.assertTrue(all(_.native_field.endswith(" Woz") and _.foreign_field.endswith(" Woz")
                                         for _ in fk.mapping))
 
+    def test_clone_rename_a_column_deletes_a_tooltip(self): # issue 189
+        tdf = TicDatFactory(table=[["Pk Field"], ["D Field 1", "D Field 2"]],
+                            table_two=[["Blah"], []])
+        tdf.set_tooltip("table", "Pk Field", "blah")
+        tdf.set_tooltip("table", "", "something")
+        tdf2 = tdf.clone_rename_a_column("table", "Pk Field", "The PK field")
+        self.assertTrue(tdf.tooltips == {('table', 'Pk Field'): 'blah', 'table': 'something'})
+        self.assertTrue(tdf2.tooltips == {('table', 'The PK field'): 'blah', 'table': 'something'})
+
     def test_foresta_command_line(self):
         # this test NOT self contained. It will connect to a testing Foresta via a live token. DON'T check
         # a live token into GitHub for all to read. Just generate as needed for test then delete from Foresta

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -1404,9 +1404,9 @@ class TicDatFactory(freezable_factory(object, "_isFrozen", {"opl_prepend", "ampl
 
         :param new_field: new name for the field
 
-        :return: a clone of the TicDatFactory, with field renamed to new_field. Data types, default values and
-                 foreign keys will reflect the new field name, but row predicates will be copied over as-is (and thus you will need
-                 to re-create them as needed).
+        :return: a clone of the TicDatFactory, with field renamed to new_field. Data types, default values,
+                 foreign keys and tooltips will reflect the new field name, but row predicates will be copied over as-is
+                 (and thus you will need to re-create them as needed).
         '''
         return utils.clone_rename_a_column(self, table, field, new_field)
     def clone_remove_a_column(self, table, field):

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -161,6 +161,8 @@ def clone_rename_a_column(tdf_pdf, table, field, new_field):
             return tuple(do_renaming(_) for _ in mp)if containerish(mp) else mp
         if needs_renaming(fk.mapping):
             rtn.add_foreign_key(fk.native_table, fk.foreign_table, do_renaming(fk.mapping))
+    if (table, field) in tdf_pdf.tooltips:
+        rtn.set_tooltip(table, new_field, tdf_pdf.tooltips[table, field])
     return rtn
 
 def clone_a_anchillary_info_schema(schema, table_restrictions, fields_to_remove=None):


### PR DESCRIPTION

- clone_rename_a_column deletes the tooltip #189
- better docstring for `PanDatFactory.add_data_row_predicate`