### PR TITLE
0.2.24.4 Internal Release

### DIFF
--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -14,7 +14,7 @@ from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
 from ticdat.opl import opl_run, create_opl_mod_text, create_opl_mod_output_text
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
-__version__ = '0.2.24.3'
+__version__ = '0.2.24.4'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "opl_run", "create_opl_mod_text", "create_opl_mod_output_text", "ampl_format",
            "gurobi_env", "verify", "faster_df_apply"]

--- a/ticdat/testing/funky.py
+++ b/ticdat/testing/funky.py
@@ -1,4 +1,8 @@
 from ticdat import TicDatFactory
 solution_schema = input_schema = TicDatFactory(table=[['field'],[]])
 def solve(dat):
+    if "speak" in dat.table:
+        return ("spoken", dat)
+    if "fail" in dat.table:
+        return ("failed message", None)
     return dat

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -576,7 +576,12 @@ def standard_main(input_schema, solution_schema, solve, case_space_table_names=F
 
 
     if foresta_based_solve is None:
-        sln = solve(dat)
+        result = solve(dat)
+        if containerish(result) and len(result) == 2:
+            msg, sln = result
+            print("**\n" + msg + "\n**\n")
+        else:
+            sln = result
     elif output_file:
         sln = foresta_based_solve(*([dat] if input_file else []))
     else:


### PR DESCRIPTION
Minor change to `standard_main` to support a `solve` function that returns `(message, sln)` instead of `sln`.

This is [related](https://github.com/decision-spot/roundoff_helper/issues/160) to Foresta only in as much as app builders might want 0.2.24.4 locally. A Foresta server itself has **no need** to deploy 0.2.24.4.