### PR TITLE
0.2.24.5 Internal Release

### DIFF
--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -14,7 +14,7 @@ from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
 from ticdat.opl import opl_run, create_opl_mod_text, create_opl_mod_output_text
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
-__version__ = '0.2.24.4'
+__version__ = '0.2.24.5'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "opl_run", "create_opl_mod_text", "create_opl_mod_output_text", "ampl_format",
            "gurobi_env", "verify", "faster_df_apply"]

--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -14,7 +14,7 @@ from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
 from ticdat.opl import opl_run, create_opl_mod_text, create_opl_mod_output_text
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
-__version__ = '0.2.24.3'
+__version__ = '0.2.24.4'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "opl_run", "create_opl_mod_text", "create_opl_mod_output_text", "ampl_format",
            "gurobi_env", "verify", "faster_df_apply"]

--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -14,7 +14,7 @@ from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
 from ticdat.opl import opl_run, create_opl_mod_text, create_opl_mod_output_text
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
-__version__ = '0.2.24.2'
+__version__ = '0.2.24.3'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "opl_run", "create_opl_mod_text", "create_opl_mod_output_text", "ampl_format",
            "gurobi_env", "verify", "faster_df_apply"]

--- a/ticdat/pandatfactory.py
+++ b/ticdat/pandatfactory.py
@@ -212,7 +212,8 @@ class PanDatFactory(object):
         if convert_dat: # this function is effectively a constructor so _ reference is ok
             assert callable(convert_dat) and len(inspect.getfullargspec(convert_dat).args) >= 1
             rtn._convert_dat[:] = [convert_dat,
-                                   {(tbl, pn) for tbl, pns in rtn._data_row_predicates.items() for pn in pns}]
+                                   {(tbl, pn) for tbl, pns in rtn._data_row_predicates.items()
+                                    for pn, rpi in pns.items() if rpi.predicate_kwargs_maker}]
         else:
             rtn._convert_dat[:] = self._convert_dat[:]
         return rtn

--- a/ticdat/pandatio.py
+++ b/ticdat/pandatio.py
@@ -161,10 +161,10 @@ class JsonPanFactory(freezable_factory(object, "_isFrozen")):
         pan_dat = self.pan_dat_factory._pre_write_adjustment(pan_dat)
         jdict = {}
         def fix_cell(x):
-            if isinstance(x, (pd.Timestamp, numpy.datetime64, datetime.datetime)):
-                return str(x)
             if pd.isnull(x):
                 return None
+            if isinstance(x, (pd.Timestamp, numpy.datetime64, datetime.datetime)):
+                return str(x)
             return x
 
         for t, (pks, dfs) in self.pan_dat_factory.schema().items():

--- a/ticdat/pandatio.py
+++ b/ticdat/pandatio.py
@@ -61,9 +61,9 @@ class JsonPanFactory(freezable_factory(object, "_isFrozen")):
         :return:
         """
         self.pan_dat_factory = pan_dat_factory
-        to_json_args = inspect.getfullargspec(pd.DataFrame.to_json).args
-        assert "orient" in to_json_args
-        self._modern_pandas = "index" in to_json_args
+        to_json_args = inspect.getfullargspec(pd.DataFrame.to_json)
+        assert "orient" in to_json_args.args + to_json_args.kwonlyargs
+        self._modern_pandas = "index" in to_json_args.args + to_json_args.kwonlyargs
         self._isFrozen = True
     def create_pan_dat(self, path_or_buf, fill_missing_fields=False, orient='split', **kwargs):
         """

--- a/ticdat/testing/funky.py
+++ b/ticdat/testing/funky.py
@@ -1,4 +1,8 @@
 from ticdat import TicDatFactory
 solution_schema = input_schema = TicDatFactory(table=[['field'],[]])
 def solve(dat):
+    if "speak" in dat.table:
+        return ("spoken", dat)
+    if "fail" in dat.table:
+        return ("failed message", None)
     return dat

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -1211,6 +1211,19 @@ class TestUtils(unittest.TestCase):
             new_sch["foreign_keys"] = sorted(new_sch["foreign_keys"])
             self.assertTrue(new_sch == simple_sch)
 
+    def test_issue_201(self):
+        tdf = TicDatFactory(table_with_stuffs=[["PK Field"], ["Data Field"]],
+                            parameters=[["Key"], ["Value"]])
+        tdf.set_data_type("table_with_stuffs", "Data Field", datetime=True)
+        tdf.add_parameter("p1", "Dec 15 1970", datetime=True)
+        tdf.add_parameter("p2", None, datetime=True, nullable=True)
+        dat = tdf.TicDat(table_with_stuffs=[["a", '2024-03-22 18:56:32.738122+46'],
+                                            ["b", '2024-03-22 18:56:32 PST']],
+                         parameters=[["p1", '2024-03-22 18:56:32 PST'], ["p2", '2024-03-22 18:56:32.738122+46']])
+        self.assertTrue(set(map(len, [tdf.find_data_type_failures(dat), tdf.find_data_row_failures(dat)])) == {1})
+        self.assertTrue(next(iter(tdf.find_data_type_failures(dat).values())).pks == ('a', ))
+        self.assertTrue(next(iter(tdf.find_data_row_failures(dat).values())) == ('p2',))
+
     def testTwentyTwo(self):
         tdf = TicDatFactory(table_with_stuffs = [["field one"], ["field two"]],
                             parameters = [["a"],["b"]])

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -1369,7 +1369,8 @@ class TicDatFactory(freezable_factory(object, "_isFrozen", {"opl_prepend", "ampl
         if convert_dat: # this function is effectively a constructor so _ reference is ok
             assert callable(convert_dat) and len(inspect.getfullargspec(convert_dat).args) >= 1
             rtn._convert_dat[:] = [convert_dat,
-                                   {(tbl, pn) for tbl, pns in rtn._data_row_predicates.items() for pn in pns}]
+                                   {(tbl, pn) for tbl, pns in rtn._data_row_predicates.items()
+                                    for pn, rpi in pns.items() if rpi.predicate_kwargs_maker}]
         else:
             rtn._convert_dat[:] = self._convert_dat[:]
         return rtn

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -576,7 +576,12 @@ def standard_main(input_schema, solution_schema, solve, case_space_table_names=F
 
 
     if foresta_based_solve is None:
-        sln = solve(dat)
+        result = solve(dat)
+        if containerish(result) and len(result) == 2:
+            msg, sln = result
+            print("**\n" + msg + "\n**\n")
+        else:
+            sln = result
     elif output_file:
         sln = foresta_based_solve(*([dat] if input_file else []))
     else:

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -263,7 +263,10 @@ class TypeDictionary(namedtuple("TypeDictionary",
         if self.datetime:
             # data is not None and dateutil_adjuster(data) is None will always be invalid, re:less of self.nullable
             # self.nullable only refers to whether the true None can be passed.
-            return isinstance(data, datetime_.datetime) or dateutil_adjuster(data) is not None
+            if isinstance(data, datetime_.datetime):
+                return True
+            munged = dateutil_adjuster(data)
+            return munged is not None and safe_apply(repr)(munged) is not None # see issue 201 for details
         if numericish(data):
             if not self.number_allowed:
                 return False


### PR DESCRIPTION
- bad timezone definition for datetime=True should trip a data type failure #201
- Failing assert "orient" in to_json_args #202
- clone should accept a convert_dat argument to enable all row predicates to convert #203
- FutureWarning: Inferring datetime64[ns] from data containing strings is deprecated #204