### PR TITLE
0.2.24.6 Internal Release

### DIFF
--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -14,7 +14,7 @@ from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
 from ticdat.opl import opl_run, create_opl_mod_text, create_opl_mod_output_text
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
-__version__ = '0.2.24.5'
+__version__ = '0.2.24.6'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "opl_run", "create_opl_mod_text", "create_opl_mod_output_text", "ampl_format",
            "gurobi_env", "verify", "faster_df_apply"]

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -1223,6 +1223,9 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(set(map(len, [tdf.find_data_type_failures(dat), tdf.find_data_row_failures(dat)])) == {1})
         self.assertTrue(next(iter(tdf.find_data_type_failures(dat).values())).pks == ('a', ))
         self.assertTrue(next(iter(tdf.find_data_row_failures(dat).values())) == ('p2',))
+        dat = tdf.json.create_tic_dat(tdf.json.write_file(dat, ""))
+        self.assertTrue(next(iter(tdf.find_data_type_failures(dat).values())).pks == ('a', ))
+        self.assertTrue(next(iter(tdf.find_data_row_failures(dat).values())) == ('p2',))
 
     def testTwentyTwo(self):
         tdf = TicDatFactory(table_with_stuffs = [["field one"], ["field two"]],

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -233,6 +233,9 @@ def dateutil_adjuster(x):
         return x
     # note that pd.Timestamp tends to create NaT from Falsey, this is ok so long as you check for null using pd.isnull
     # also, pd.Timestampp can do weird things making Timestamps from numbers, so not enabling that.
+    def _repr_safe(x): # see issues 201 and 208
+        if x is not None and safe_apply(repr)(x) is not None:
+            return x
     def _try_to_timestamp(y):
         if pd and not numericish(y):
             rtn = safe_apply(pd.Timestamp)(y)
@@ -240,11 +243,11 @@ def dateutil_adjuster(x):
                 return rtn
         if dateutil:
             return safe_apply(dateutil.parser.parse)(y)
-    rtn = _try_to_timestamp(x)
+    rtn = _repr_safe(_try_to_timestamp(x))
     if rtn is not None:
         return rtn
     if not numericish(x):
-        return _try_to_timestamp(str(x))
+        return _repr_safe(_try_to_timestamp(str(x)))
 
 def acceptable_default(v) :
     return numericish(v) or stringish(v) or v in [True, False] or v is None


### PR DESCRIPTION
Quickie release due to the prior release not fully addressing "bad timezone definition for `datetime=True` should trip a data type failure" #201

See also #208