### PR TITLE
0.2.27 Release

### DIFF
--- a/ticdat/__init__.py
+++ b/ticdat/__init__.py
@@ -13,6 +13,6 @@ from ticdat.utils import Sloc, LogFile, Progress, Slicer, standard_main, \
                          gurobi_env, ampl_format, verify, faster_df_apply
 from ticdat.model import Model
 from ticdat.pandatfactory import PanDatFactory
-__version__ = '0.2.26'
+__version__ = '0.2.27'
 __all__ = ["TicDatFactory", "PanDatFactory", "freeze_me", "LogFile", "Sloc", "Slicer", "Progress", "standard_main",
            "Model", "ampl_format", "gurobi_env", "verify", "faster_df_apply"]

--- a/ticdat/pandatio.py
+++ b/ticdat/pandatio.py
@@ -8,6 +8,7 @@ import uuid
 import os
 from ticdat.utils import freezable_factory, verify, case_space_to_pretty, pd, TicDatError, FrozenDict, all_fields
 from ticdat.utils import all_underscore_replacements, stringish, dictish, containerish, debug_break, faster_df_apply
+from ticdat.utils import safe_apply
 from itertools import product, chain
 from collections import defaultdict
 import datetime
@@ -94,7 +95,7 @@ class JsonPanFactory(freezable_factory(object, "_isFrozen")):
         To address this, you need to either use set_data_type for your
         PanDatFactory, or specify "dtype" in kwargs. (The former is obviously better).
         """
-        if stringish(path_or_buf) and os.path.exists(path_or_buf):
+        if safe_apply(os.path.exists)(path_or_buf):
             verify(os.path.isfile(path_or_buf), "%s appears to be a directory and not a file." % path_or_buf)
             with open(path_or_buf, "r") as f:
                 loaded_dict = json.load(f)

--- a/ticdat/testing/testxls.py
+++ b/ticdat/testing/testxls.py
@@ -594,7 +594,7 @@ class TestXls(unittest.TestCase):
             ["June 13 1960 4:30PM", "Dec 11 1970 1AM", "Sept 11 2001 9:30AM"]))})
         tdf = TicDatFactory(cool_runnings = [["a"],[]])
         tdf.set_data_type("cool_runnings", "a", datetime=True)
-        df.to_excel(file, "Cool Runnings")
+        df.to_excel(file, sheet_name="Cool Runnings")
         dat = tdf.xls.create_tic_dat(file)
         self.assertTrue(set(dat.cool_runnings) == set(df["a"]))
         for x, y in zip(sorted(dat.cool_runnings), sorted(set(df["a"]))):

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -37,15 +37,12 @@ import warnings
 
 def faster_df_apply(df, func, trip_wire_check=None):
     """
-    pandas.DataFrame.apply is rarely used because it is slow. It is slow because it creates a Series for each row
-    of the DataFrame, and passes this Series to the function. faster_df_apply creates a dict for each row of the
-    DataFrame instead, and as a result is **much** faster.
+    In earlier versions of, DataFrame.apply(func=func, axis=1) was very slow. faster_df_apply was faster.
+    See https://bit.ly/3xnLFld for details.
 
-    See https://bit.ly/3xnLFld.
-
-    It's certainly possible newer versions of pandas will implement a more performant DataFrame.apply. The broader
-    point is, row-wise apply should not be discarded wholesale for performance reasons, as DataFrame.itertuples
-    is reasonably fast
+    Currently, (pandas 2.2.2 or newer) it appears that DataFrame.apply(func=func, axis=1) will be faster than
+    faster_df_apply. We're investigating this matter to be sure. Assuming these results hold up, a future release
+    of ticdat will simply be a redirect.
 
     :param df: a DataFrame
 

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -44,6 +44,8 @@ def faster_df_apply(df, func, trip_wire_check=None):
     faster_df_apply. We're investigating this matter to be sure. Assuming these results hold up, a future release
     of ticdat will simply be a redirect.
 
+    See https://github.com/ticdat/ticdat/issues/228 for continuing updates.
+
     :param df: a DataFrame
 
     :param func: a function to apply to each row of the DataFrame. The function should accept a fieldname->data


### PR DESCRIPTION
- PanDatFactory.find_data_type_failures no longer use faster_df_apply #229
- support pathlib.Path arguments to dat constructors #227 (partial fix - `PanDat` is covered)



